### PR TITLE
[fix] Jwt 예외 처리 추가 및 TestToken 발급 추가

### DIFF
--- a/src/main/java/org/kkumulkkum/server/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/kkumulkkum/server/auth/JwtAuthenticationFilter.java
@@ -31,11 +31,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
         final String token = getJwtFromRequest(request);
-        jwtTokenValidator.validateAccessToken(token);
-        Long userId = jwtTokenProvider.getUserIdFromJwt(token);
-        UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
-        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        if (StringUtils.hasText(token)) {
+            jwtTokenValidator.validateAccessToken(token);
+            Long userId = jwtTokenProvider.getUserIdFromJwt(token);
+            UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/org/kkumulkkum/server/auth/JwtExceptionFilter.java
+++ b/src/main/java/org/kkumulkkum/server/auth/JwtExceptionFilter.java
@@ -1,0 +1,45 @@
+package org.kkumulkkum.server.auth;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.kkumulkkum.server.exception.code.BusinessErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthException e) {
+            log.error("FilterException throw AuthException : {}", e.getErrorCode().getMessage());
+            request.setAttribute("exception", e.getErrorCode());
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            log.error("FilterException throw JwtException Exception : {}", e.getMessage());
+            request.setAttribute("exception", AuthErrorCode.UNKNOWN_TOKEN);
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("FilterException throw Exception : {}", e.toString());
+            request.setAttribute("exception", BusinessErrorCode.INTERNAL_SERVER_ERROR);
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.auth.CustomAccessDeniedHandler;
 import org.kkumulkkum.server.auth.CustomJwtAuthenticationEntryPoint;
 import org.kkumulkkum.server.auth.JwtAuthenticationFilter;
+import org.kkumulkkum.server.auth.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
@@ -44,7 +46,8 @@ public class SecurityConfig {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
                     auth.anyRequest().authenticated();
                 })
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
@@ -22,7 +22,9 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {};
+    private static final String[] AUTH_WHITE_LIST = {
+            "/api/v1/test/**",
+    };
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/org/kkumulkkum/server/controller/TestController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/TestController.java
@@ -1,16 +1,23 @@
 package org.kkumulkkum.server.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.auth.jwt.JwtTokenProvider;
+import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
 import org.kkumulkkum.server.dto.test.TestDto;
 import org.kkumulkkum.server.exception.BusinessException;
 import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class TestController {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/test/void")
     public ResponseEntity<Void> testVoid() {
@@ -30,5 +37,12 @@ public class TestController {
     @GetMapping("/test/business")
     public ResponseEntity<Void> testBusiness() {
         throw new BusinessException(BusinessErrorCode.BAD_REQUEST);
+    }
+
+    @GetMapping("/test/token/{userId}")
+    public ResponseEntity<JwtTokenDto> testToken(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(jwtTokenProvider.issueTokens(userId));
     }
 }

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -8,12 +8,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements DefaultErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40191, "인증되지 않은 사용자입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40192, "액세스 토큰의 형식이 올바르지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 40193, "액세스 토큰이 만료되었습니다."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, 40194, "지원하지 않는 토큰 형식입니다."),
-    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, 40195, "토큰이 제공되지 않았습니다."),
-    MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40196, "리프레시 토큰이 일치하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40190, "인증되지 않은 사용자입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40191, "액세스 토큰의 형식이 올바르지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 40192, "액세스 토큰이 만료되었습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, 40193, "지원하지 않는 토큰 형식입니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, 40194, "토큰이 제공되지 않았습니다."),
+    MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40195, "리프레시 토큰이 일치하지 않습니다."),
+    UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED, 40196, "알 수 없는 토큰입니다."),
     ;
 
     private HttpStatus httpStatus;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #17

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- SecurityConfig에서 whitelist에 API를 추가해줘도 filter는 지나가기 때문에 JwtAuthenticationFilter에서 token이 필요 없는 API의 경우에 null을 jwt로 인지하고 값을 얻어오려해 에러가 나는 부분을 if문을 통해 수정해주었습니다.
https://github.com/OMZigak/KKUM_SERVER/blob/4946204125d3b3c31972169c1871b6a1e1970275/src/main/java/org/kkumulkkum/server/auth/JwtAuthenticationFilter.java#L30-L36
- filter단에서 일어나는 Jwt Exception들을 상황에 맞는 응답값으로 바꿔주기 위해 JwtExceptionFilter를 생성하고 AuthenticationEntryPoint를 수정했습니다.
- JwtExceptionFilter를 JwtAuthenticationFilter 전에 넣고 try문으로 다음 filter를 실행시킴을 통해 jwtExceptionFilter에서 catch로 exception을 받을 수 있습니다.
https://github.com/OMZigak/KKUM_SERVER/blob/4946204125d3b3c31972169c1871b6a1e1970275/src/main/java/org/kkumulkkum/server/auth/JwtExceptionFilter.java#L21-L32
- AuthenticationEnrtyPoint에서 어떤 에러였는지 알 수 있도록 request에 'exception'이라는 attribute를 추가해서 에러 상황을 저장해주었습니다.
- 추가적으로 작업할 때 편의를 위해 Token을 발급받는 API를 TestController에 제작하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
JwtAuthenticationFilter에서 고민중인 점이 있습니다. 어차피 잘못된 jwt라면 userId를 가져오는 과정 중 error가 일어날 것일텐데 굳이 validateToken과 같은 과정이 필요한지 고민이 됩니다. 물론 그에 따라 코드 스타일이 달라질 것 같지만 굳이 jwt를 두 번 해석해야하는지 고민이 조금 됩니다.