### PR TITLE
[feat] 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// Social Login
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package org.kkumulkkum.server.advice;
 
 import lombok.extern.slf4j.Slf4j;
+import org.kkumulkkum.server.exception.AuthException;
 import org.kkumulkkum.server.exception.BusinessException;
 import org.kkumulkkum.server.exception.MeetingException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
 import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.kkumulkkum.server.exception.code.MeetingErrorCode;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {MeetingException.class})
     public ResponseEntity<MeetingErrorCode> handleMeetingException(MeetingException e) {
         log.error("GlobalExceptionHandler catch MeetingException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    @ExceptionHandler(value = {AuthException.class})
+    public ResponseEntity<AuthErrorCode> handleAuthException(AuthException e) {
+        log.error("GlobalExceptionHandler catch AuthException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/AppleFeignClient.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/AppleFeignClient.java
@@ -1,0 +1,12 @@
+package org.kkumulkkum.server.auth.openfeign.apple;
+
+import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKeys;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
+public interface AppleFeignClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/ApplePublicKey.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/ApplePublicKey.java
@@ -1,0 +1,7 @@
+package org.kkumulkkum.server.auth.openfeign.apple.dto;
+
+public record ApplePublicKey(
+        String kty, String kid, String use, String alg, String n, String e, String email
+) {
+
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/ApplePublicKeys.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/ApplePublicKeys.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.auth.openfeign.apple.dto;
+
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+
+import java.util.List;
+
+public record ApplePublicKeys(List<ApplePublicKey> keys) {
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.alg().equals(alg) && k.kid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_APPLE_PUBLIC_KEY));
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
@@ -1,0 +1,31 @@
+package org.kkumulkkum.server.auth.openfeign.apple.service;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.auth.openfeign.apple.AppleFeignClient;
+import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKeys;
+import org.kkumulkkum.server.auth.openfeign.apple.verify.AppleJwtParser;
+import org.kkumulkkum.server.auth.openfeign.apple.verify.PublicKeyGenerator;
+import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
+import org.springframework.stereotype.Service;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+
+    private final AppleFeignClient appleFeignClient;
+    private final AppleJwtParser appleJwtParser;
+    private final PublicKeyGenerator publicKeyGenerator;
+    public SocialUserDto getSocialUserInfo(String identityToken) {
+
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        return SocialUserDto.of(claims.get("sub", String.class), claims.get("email", String.class));
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/AppleJwtParser.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/AppleJwtParser.java
@@ -1,0 +1,46 @@
+package org.kkumulkkum.server.auth.openfeign.apple.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new AuthException(AuthErrorCode.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.EXPIRED_APPLE_IDENTITY_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/PublicKeyGenerator.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/PublicKeyGenerator.java
@@ -1,0 +1,49 @@
+package org.kkumulkkum.server.auth.openfeign.apple.verify;
+
+import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKey;
+import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKeys;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) {
+        byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new AuthException(AuthErrorCode.CREATE_PUBLIC_KEY_EXCEPTION);
+        }
+    }
+}
+

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/KakaoFeignClient.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/KakaoFeignClient.java
@@ -1,0 +1,13 @@
+package org.kkumulkkum.server.auth.openfeign.kakao;
+
+import org.kkumulkkum.server.auth.openfeign.kakao.dto.KakaoUserDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoFeignClient", url = "https://kapi.kakao.com")
+public interface KakaoFeignClient {
+    @GetMapping(value = "/v2/user/me")
+    KakaoUserDto getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/KakaoAccount.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/KakaoAccount.java
@@ -1,0 +1,6 @@
+package org.kkumulkkum.server.auth.openfeign.kakao.dto;
+
+public record KakaoAccount(
+        String email
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/KakaoUserDto.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/KakaoUserDto.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.auth.openfeign.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoUserDto(
+        Long id,
+        KakaoAccount kakaoAccount
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/SocialUserDto.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/dto/SocialUserDto.java
@@ -1,0 +1,8 @@
+package org.kkumulkkum.server.auth.openfeign.kakao.dto;
+
+public record SocialUserDto(String platformId, String email) {
+
+    public static SocialUserDto of(String platformId, String email) {
+        return new SocialUserDto(platformId, email);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/service/KakaoService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/service/KakaoService.java
@@ -1,0 +1,21 @@
+package org.kkumulkkum.server.auth.openfeign.kakao.service;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.auth.openfeign.kakao.KakaoFeignClient;
+import org.kkumulkkum.server.auth.openfeign.kakao.dto.KakaoUserDto;
+import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
+import org.kkumulkkum.server.constant.Constant;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final KakaoFeignClient kakaoFeignClient;
+    public SocialUserDto getSocialUserInfo(String providerToken) {
+        KakaoUserDto kakaoUserDto = kakaoFeignClient.getUserInformation(Constant.BEARER_TOKEN_PREFIX + providerToken);
+        return SocialUserDto.of(
+                kakaoUserDto.id().toString(),
+                kakaoUserDto.kakaoAccount().email());
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/config/FeignClientConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.kkumulkkum.server.config;
+
+import org.kkumulkkum.server.ServerApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = ServerApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITE_LIST = {
             "/api/v1/test/**",
+            "/api/v1/auth/signin"
     };
 
     @Bean

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -1,0 +1,28 @@
+package org.kkumulkkum.server.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.constant.Constant;
+import org.kkumulkkum.server.dto.auth.request.UserLoginDto;
+import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
+import org.kkumulkkum.server.service.auth.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/auth/signin")
+    public ResponseEntity<JwtTokenDto> signin(
+            @NotNull @RequestHeader(Constant.AUTHORIZATION_HEADER) final String providerToken,
+            @Valid @RequestBody UserLoginDto userLoginDto
+    ) {
+        return ResponseEntity.ok(authService.signin(providerToken, userLoginDto));
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
     @PostMapping("/auth/signin")
     public ResponseEntity<JwtTokenDto> signin(
             @NotNull @RequestHeader(Constant.AUTHORIZATION_HEADER) final String providerToken,
-            @Valid @RequestBody UserLoginDto userLoginDto
+            @Valid @RequestBody final UserLoginDto userLoginDto
     ) {
         return ResponseEntity.ok(authService.signin(providerToken, userLoginDto));
     }

--- a/src/main/java/org/kkumulkkum/server/domain/Token.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Token.java
@@ -1,0 +1,28 @@
+package org.kkumulkkum.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value="token", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Token {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    @Builder
+    public Token(Long id, String refreshToken) {
+        this.id = id;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
+++ b/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
@@ -19,6 +19,8 @@ public class UserInfo extends BaseTimeEntity {
 
     private String profileImg;
 
+    private String email;
+
     private int level;
 
     private int promiseCount;
@@ -34,15 +36,14 @@ public class UserInfo extends BaseTimeEntity {
     @Builder
     public UserInfo(String name,
                     String profileImg,
-                    int level,
-                    int promiseCount,
-                    int tardyCount,
+                    String email,
                     User user) {
         this.name = name;
         this.profileImg = profileImg;
-        this.level = level;
-        this.promiseCount = promiseCount;
-        this.tardyCount = tardyCount;
+        this.email = email;
+        this.level = 1;
+        this.promiseCount = 0;
+        this.tardyCount = 0;
         this.user = user;
         this.tardySum = 0L;
     }

--- a/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
@@ -1,0 +1,8 @@
+package org.kkumulkkum.server.dto.auth.request;
+
+import org.kkumulkkum.server.domain.enums.Provider;
+
+public record UserLoginDto(
+        Provider provider
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/exception/UserException.java
+++ b/src/main/java/org/kkumulkkum/server/exception/UserException.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.exception.code.UserErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class UserException extends RuntimeException {
+    private final UserErrorCode errorCode;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -7,7 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements DefaultErrorCode {
+    // 400 Bad Request
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, 40091, "유효하지 않은 소셜 플랫폼입니다."),
+    INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, 40092,"유효하지 않은 Apple Public Key입니다."),
+    CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, 40093,"Apple public key 생성에 문제가 발생했습니다."),
+    INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40094, "Apple Identity Token 형식이 올바르지 않습니다."),
+    EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40495, "Apple Identity Token 유효기간이 만료됐습니다."),
 
+    // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40190, "인증되지 않은 사용자입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40191, "액세스 토큰의 형식이 올바르지 않습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 40192, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements DefaultErrorCode {
+    // 404 Not Found
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40410, "유저를 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/kkumulkkum/server/repository/TokenRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/TokenRepository.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.repository;
+
+import org.kkumulkkum.server.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+
+    Optional<Token> findIdByRefreshToken(String refreshToken);
+}

--- a/src/main/java/org/kkumulkkum/server/repository/UserRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/UserRepository.java
@@ -1,7 +1,14 @@
 package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.domain.enums.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByProviderIdAndProvider(String serialId, Provider provider);
+
+    Optional<User> findByProviderIdAndProvider(String providerId, Provider provider);
 }

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -1,0 +1,79 @@
+package org.kkumulkkum.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.auth.jwt.JwtTokenProvider;
+import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
+import org.kkumulkkum.server.auth.openfeign.apple.service.AppleService;
+import org.kkumulkkum.server.auth.openfeign.kakao.service.KakaoService;
+import org.kkumulkkum.server.domain.Token;
+import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.domain.UserInfo;
+import org.kkumulkkum.server.domain.enums.Provider;
+import org.kkumulkkum.server.domain.enums.Role;
+import org.kkumulkkum.server.dto.auth.request.UserLoginDto;
+import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.kkumulkkum.server.service.user.UserRetriever;
+import org.kkumulkkum.server.service.user.UserSaver;
+import org.kkumulkkum.server.service.userInfo.UserInfoSaver;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoService kakaoService;
+    private final AppleService appleService;
+    private final UserRetriever userRetriever;
+    private final UserSaver userSaver;
+    private final UserInfoSaver userInfoSaver;
+    private final TokenSaver tokenSaver;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public JwtTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
+        SocialUserDto socialUserDto = getSocialInfo(providerToken, userLoginDto);
+        User user = loadOrCreateUser(userLoginDto.provider(), socialUserDto);
+        JwtTokenDto tokens = jwtTokenProvider.issueTokens(user.getId());
+        tokenSaver.save(
+                Token.builder()
+                        .id(user.getId())
+                        .refreshToken(tokens.refreshToken())
+                        .build()
+        );
+        return tokens;
+    }
+
+    private SocialUserDto getSocialInfo(final String providerToken, final UserLoginDto userLoginDto) {
+        if (userLoginDto.provider().toString().equals("KAKAO")){
+            return kakaoService.getSocialUserInfo(providerToken);
+        } else if (userLoginDto.provider().toString().equals("APPLE")){
+            return appleService.getSocialUserInfo(providerToken);
+        } else {
+            throw new AuthException(AuthErrorCode.INVALID_PROVIDER);
+        }
+    }
+
+    private User loadOrCreateUser(Provider provider, SocialUserDto socialUserDto){
+        boolean isRegistered = userRetriever.existsByProviderIdAndProvider(socialUserDto.platformId(), provider);
+
+        if (!isRegistered){
+            User newUser = User.builder()
+                    .provider(provider)
+                    .providerId(socialUserDto.platformId())
+                    .role(Role.USER)
+                    .build();
+
+            UserInfo newUserInfo = UserInfo.builder()
+                    .email(socialUserDto.email())
+                    .build();
+
+            userSaver.save(newUser);
+            userInfoSaver.save(newUserInfo);
+        }
+
+        return userRetriever.findByProviderIdAndProvider(socialUserDto.platformId(), provider);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
         }
     }
 
-    private User loadOrCreateUser(Provider provider, SocialUserDto socialUserDto){
+    private User loadOrCreateUser(final Provider provider, final SocialUserDto socialUserDto){
         boolean isRegistered = userRetriever.existsByProviderIdAndProvider(socialUserDto.platformId(), provider);
 
         if (!isRegistered){

--- a/src/main/java/org/kkumulkkum/server/service/auth/TokenSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/TokenSaver.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Token;
+import org.kkumulkkum.server.repository.TokenRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenSaver {
+
+    private final TokenRepository tokenRepository;
+
+    public Token save(final Token token){
+        return tokenRepository.save(token);
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/service/user/UserRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/user/UserRetriever.java
@@ -1,0 +1,27 @@
+package org.kkumulkkum.server.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.domain.enums.Provider;
+import org.kkumulkkum.server.exception.UserException;
+import org.kkumulkkum.server.exception.code.UserErrorCode;
+import org.kkumulkkum.server.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserRetriever {
+
+    private final UserRepository userRepository;
+
+    public boolean existsByProviderIdAndProvider(final String providerId, final Provider provider) {
+        return userRepository.existsByProviderIdAndProvider(providerId, provider);
+    }
+
+    public User findByProviderIdAndProvider(final String providerId, Provider provider) {
+        return userRepository.findByProviderIdAndProvider(providerId, provider)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/user/UserSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/user/UserSaver.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSaver {
+
+    private final UserRepository userRepository;
+
+    public User save(final User user){
+        return userRepository.save(user);
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRetriever.java
@@ -1,0 +1,4 @@
+package org.kkumulkkum.server.service.userInfo;
+
+public class UserInfoRetriever {
+}

--- a/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoSaver.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.service.userInfo;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.UserInfo;
+import org.kkumulkkum.server.repository.UserInfoRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserInfoSaver {
+
+    private final UserInfoRepository userInfoRepository;
+
+    public UserInfo save(final UserInfo user){
+        return userInfoRepository.save(user);
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #10 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- openFeign 관련 세팅했습니다.
- 카카오 로그인 openFeign 관련 코드 작성 및 유저 정보를 받아오기 위한 KakaoService를 구현했습니다.
- Apple 토큰을 받아서 사용자의 공개키를 확인하고, 이를 사용하여 토큰에서 클레임을 추출한 뒤 사용자의 고유 식별자와 이메일 정보를 가져오는 AppleService를 구현했습니다.
- 소셜 로그인 로직을 구현하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)