### PR TITLE
[feat] Meeting 관련 API 생성

### DIFF
--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.kkumulkkum.server.exception.code.MeetingErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -39,6 +40,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(BusinessErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
                 .body(BusinessErrorCode.NOT_FOUND_END_POINT);
+    }
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<BusinessErrorCode> handleException(MethodArgumentNotValidException e) {
+        log.error("handleException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
+        return ResponseEntity
+                .status(BusinessErrorCode.INVALID_ARGUMENTS.getHttpStatus())
+                .body(BusinessErrorCode.INVALID_ARGUMENTS);
     }
 
     // 기본 예외

--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -6,12 +6,10 @@ import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
 import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
 import org.kkumulkkum.server.service.meeting.MeetingService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -40,6 +38,13 @@ public class MeetingController {
     ) {
         meetingService.registerMeeting(userId, meetingRegisterDto);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/meetings")
+    public ResponseEntity<MeetingsDto> getMeetings(
+            @UserId Long userId
+    ) {
+        return ResponseEntity.ok(meetingService.getMeetings(userId));
     }
 
 }

--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -8,6 +8,7 @@ import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
 import org.kkumulkkum.server.dto.meeting.response.MeetingDto;
 import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
+import org.kkumulkkum.server.dto.member.response.MembersDto;
 import org.kkumulkkum.server.service.meeting.MeetingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -54,6 +55,14 @@ public class MeetingController {
             @PathVariable Long meetingId
     ) {
         return ResponseEntity.ok(meetingService.getMeeting(userId, meetingId));
+    }
+
+    @GetMapping("/meetings/{meetingId}/members")
+    public ResponseEntity<MembersDto> getMembers(
+            @UserId Long userId,
+            @PathVariable Long meetingId
+    ) {
+        return ResponseEntity.ok(meetingService.getMembers(userId, meetingId));
     }
 
 }

--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -1,0 +1,35 @@
+package org.kkumulkkum.server.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.UserId;
+import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
+import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.service.meeting.MeetingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @PostMapping("/meetings")
+    public ResponseEntity<CreatedMeetingDto> createMeeting(
+            @UserId Long userId,
+            @Valid @RequestBody MeetingCreateDto meetingCreateDto
+    ) {
+        CreatedMeetingDto createdMeetingDto = meetingService.createMeeting(userId, meetingCreateDto);
+        return ResponseEntity
+                .created(URI.create(createdMeetingDto.id().toString()))
+                .body(createdMeetingDto);
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -6,6 +6,7 @@ import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
 import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.dto.meeting.response.MeetingDto;
 import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
 import org.kkumulkkum.server.service.meeting.MeetingService;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +46,14 @@ public class MeetingController {
             @UserId Long userId
     ) {
         return ResponseEntity.ok(meetingService.getMeetings(userId));
+    }
+
+    @GetMapping("/meetings/{meetingId}")
+    public ResponseEntity<MeetingDto> getMeeting(
+            @UserId Long userId,
+            @PathVariable Long meetingId
+    ) {
+        return ResponseEntity.ok(meetingService.getMeeting(userId, meetingId));
     }
 
 }

--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
+import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
 import org.kkumulkkum.server.service.meeting.MeetingService;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,15 @@ public class MeetingController {
         return ResponseEntity
                 .created(URI.create(createdMeetingDto.id().toString()))
                 .body(createdMeetingDto);
+    }
+
+    @PostMapping("/meetings/register")
+    public ResponseEntity<Void> registerMeeting(
+            @UserId Long userId,
+            @Valid @RequestBody MeetingRegisterDto meetingRegisterDto
+    ) {
+        meetingService.registerMeeting(userId, meetingRegisterDto);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/org/kkumulkkum/server/domain/BaseTimeEntity.java
+++ b/src/main/java/org/kkumulkkum/server/domain/BaseTimeEntity.java
@@ -2,12 +2,14 @@ package org.kkumulkkum.server.domain;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {

--- a/src/main/java/org/kkumulkkum/server/domain/Meeting.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Meeting.java
@@ -1,13 +1,12 @@
 package org.kkumulkkum.server.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,6 +20,9 @@ public class Meeting extends BaseTimeEntity {
     private String name;
 
     private String invitationCode;
+
+    @OneToMany(mappedBy = "meeting")
+    private List<Member> members;
 
     @Builder
     public Meeting(String name, String invitationCode) {

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/request/MeetingCreateDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/request/MeetingCreateDto.java
@@ -1,0 +1,10 @@
+package org.kkumulkkum.server.dto.meeting.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MeetingCreateDto(
+        @NotBlank @Size(max = 10)
+        String name
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/request/MeetingRegisterDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/request/MeetingRegisterDto.java
@@ -1,0 +1,6 @@
+package org.kkumulkkum.server.dto.meeting.request;
+
+public record MeetingRegisterDto (
+    String invitationCode
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/response/CreatedMeetingDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/response/CreatedMeetingDto.java
@@ -1,0 +1,10 @@
+package org.kkumulkkum.server.dto.meeting.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record CreatedMeetingDto(
+        @JsonIgnore
+        Long id,
+        String invitationCode
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingDto.java
@@ -1,0 +1,25 @@
+package org.kkumulkkum.server.dto.meeting.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.kkumulkkum.server.domain.Meeting;
+
+import java.time.LocalDateTime;
+
+public record MeetingDto (
+        Long id,
+        String name,
+        @JsonFormat(pattern = "yyyy-MM-DD")
+        LocalDateTime createdAt,
+        int metCount,
+        String invitationCode
+) {
+    public static MeetingDto of(Meeting meeting) {
+        return new MeetingDto(
+                meeting.getId(),
+                meeting.getName(),
+                meeting.getCreatedAt(),
+                meeting.getMembers().size(),
+                meeting.getInvitationCode()
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingsDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingsDto.java
@@ -1,0 +1,34 @@
+package org.kkumulkkum.server.dto.meeting.response;
+
+import org.kkumulkkum.server.domain.Meeting;
+
+import java.util.List;
+
+public record MeetingsDto (
+        int count,
+        List<MeetingDto> meetings
+) {
+
+    public static MeetingsDto of(List<Meeting> meetings) {
+        return new MeetingsDto(
+                meetings.size(),
+                meetings.stream()
+                        .map(MeetingDto::of)
+                        .toList()
+        );
+    }
+
+    public record MeetingDto (
+            Long id,
+            String name,
+            int memberCount
+    ) {
+        public static MeetingDto of(Meeting meeting) {
+            return new MeetingDto(
+                    meeting.getId(),
+                    meeting.getName(),
+                    meeting.getMembers().size()
+            );
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/member/MemberUserInfoDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/member/MemberUserInfoDto.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.dto.member;
+
+public record MemberUserInfoDto(
+        Long id,
+        String name,
+        String profileImg
+) {
+    public static MemberUserInfoDto of(Long id, String name, String profileImg) {
+        return new MemberUserInfoDto(
+                id,
+                name,
+                profileImg
+        );
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/dto/member/response/MemberDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/member/response/MemberDto.java
@@ -1,0 +1,15 @@
+package org.kkumulkkum.server.dto.member.response;
+
+public record MemberDto(
+        Long id,
+        String name,
+        String profileImg
+) {
+    public static MemberDto of(Long id, String name, String profileImg) {
+        return new MemberDto(
+                id,
+                name,
+                profileImg
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/member/response/MembersDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/member/response/MembersDto.java
@@ -1,0 +1,15 @@
+package org.kkumulkkum.server.dto.member.response;
+
+import java.util.List;
+
+public record MembersDto(
+        int memberCount,
+        List<MemberDto> members
+) {
+    public static MembersDto of(List<MemberDto> members) {
+        return new MembersDto(
+                members.size(),
+                members
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/exception/UserException.java
+++ b/src/main/java/org/kkumulkkum/server/exception/UserException.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.exception.code.UserErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class UserException extends RuntimeException {
+    private final UserErrorCode errorCode;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/BusinessErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/BusinessErrorCode.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum BusinessErrorCode implements DefaultErrorCode {
-
+    // 400 Bad Request
     BAD_REQUEST(HttpStatus.BAD_REQUEST,40000, "잘못된 요청입니다."),
+    INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, 40001, "인자의 형식이 올바르지 않습니다."),
+    // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND,40400, "요청한 정보를 찾을 수 없습니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND,40401, "요청한 엔드포인트를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,50000, "서버 내부 오류입니다."),

--- a/src/main/java/org/kkumulkkum/server/exception/code/MeetingErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/MeetingErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum MeetingErrorCode implements DefaultErrorCode {
     // 404 Not Found
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, 40420, "모임을 찾을 수 없습니다."),
+    // 409 Conflict
+    ALREADY_JOINED(HttpStatus.CONFLICT, 40910, "이미 참여한 모임입니다."),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/org/kkumulkkum/server/exception/code/MeetingErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/MeetingErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum MeetingErrorCode implements DefaultErrorCode {
+    // 403 Forbidden
+    NOT_JOINED_MEETING(HttpStatus.FORBIDDEN, 40310, "참여하지 않은 모임입니다."),
     // 404 Not Found
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, 40420, "모임을 찾을 수 없습니다."),
     // 409 Conflict

--- a/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum UserErrorCode implements DefaultErrorCode {
     // 404 Not Found
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40410, "모임을 찾을 수 없습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40410, "유저를 찾을 수 없습니다."),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/UserErrorCode.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements DefaultErrorCode {
+    // 404 Not Found
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40410, "모임을 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
@@ -3,8 +3,12 @@ package org.kkumulkkum.server.repository;
 import org.kkumulkkum.server.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     boolean existsByInvitationCode(String invitationCode);
+
+    Optional<Meeting> findByInvitationCode(String invitationCode);
 
 }

--- a/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
@@ -2,7 +2,9 @@ package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
@@ -10,5 +12,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     boolean existsByInvitationCode(String invitationCode);
 
     Optional<Meeting> findByInvitationCode(String invitationCode);
+
+    @Query("SELECT m FROM Meeting m JOIN m.members mem WHERE mem.user.id = :userId")
+    List<Meeting> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MeetingRepository.java
@@ -4,4 +4,7 @@ import org.kkumulkkum.server.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    boolean existsByInvitationCode(String invitationCode);
+
 }

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -1,12 +1,22 @@
 package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.Member;
+import org.kkumulkkum.server.dto.member.MemberUserInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END " +
             "FROM Member m WHERE m.user.id = :userId AND m.meeting.id = :meetingId")
-    public boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
+    boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
+
+    @Query("SELECT new org.kkumulkkum.server.dto.member.MemberUserInfoDto" +
+            "(m.id, ui.name, ui.profileImg) " +
+            "FROM Member m " +
+            "JOIN UserInfo ui ON m.user.id = ui.user.id " +
+            "WHERE m.meeting.id = :meetingId")
+    List<MemberUserInfoDto> findAllByMeetingId(Long meetingId);
 }

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -2,6 +2,11 @@ package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM Member m WHERE m.user.id = :userId AND m.meeting.id = :meetingId")
+    public boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.service.meeting;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.MeetingRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingRetriever {
+
+    private final MeetingRepository meetingRepository;
+
+    public boolean existsByInvitationCode(String invitationCode) {
+        return meetingRepository.existsByInvitationCode(invitationCode);
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
@@ -7,6 +7,8 @@ import org.kkumulkkum.server.exception.code.MeetingErrorCode;
 import org.kkumulkkum.server.repository.MeetingRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class MeetingRetriever {
@@ -20,5 +22,9 @@ public class MeetingRetriever {
     public Meeting findByInvitationCode(String invitationCode) {
         return meetingRepository.findByInvitationCode(invitationCode)
                 .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_FOUND_MEETING));
+    }
+
+    public List<Meeting> findAllByUserId(Long userId) {
+        return meetingRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
@@ -1,6 +1,9 @@
 package org.kkumulkkum.server.service.meeting;
 
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Meeting;
+import org.kkumulkkum.server.exception.MeetingException;
+import org.kkumulkkum.server.exception.code.MeetingErrorCode;
 import org.kkumulkkum.server.repository.MeetingRepository;
 import org.springframework.stereotype.Component;
 
@@ -14,4 +17,8 @@ public class MeetingRetriever {
         return meetingRepository.existsByInvitationCode(invitationCode);
     }
 
+    public Meeting findByInvitationCode(String invitationCode) {
+        return meetingRepository.findByInvitationCode(invitationCode)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_FOUND_MEETING));
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingRetriever.java
@@ -27,4 +27,9 @@ public class MeetingRetriever {
     public List<Meeting> findAllByUserId(Long userId) {
         return meetingRepository.findAllByUserId(userId);
     }
+
+    public Meeting findById(Long meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_FOUND_MEETING));
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingSaver.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.service.meeting;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Meeting;
+import org.kkumulkkum.server.repository.MeetingRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingSaver {
+
+    private final MeetingRepository meetingRepository;
+
+    public void save(final Meeting meeting) {
+        meetingRepository.save(meeting);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
@@ -6,6 +6,7 @@ import org.kkumulkkum.server.domain.Member;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
 import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.dto.meeting.response.MeetingDto;
 import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
 import org.kkumulkkum.server.exception.MeetingException;
 import org.kkumulkkum.server.exception.code.MeetingErrorCode;
@@ -61,6 +62,13 @@ public class MeetingService {
     public MeetingsDto getMeetings(Long userId) {
         List<Meeting> meetings = meetingRetriever.findAllByUserId(userId);
         return MeetingsDto.of(meetings);
+    }
+
+    public MeetingDto getMeeting(Long userId, Long meetingId) {
+        if (!memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId)) {
+            throw new MeetingException(MeetingErrorCode.NOT_JOINED_MEETING);
+        }
+        return MeetingDto.of(meetingRetriever.findById(meetingId));
     }
 
     private String generateInvitationCode() {

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
@@ -6,11 +6,13 @@ import org.kkumulkkum.server.domain.Member;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
 import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
 import org.kkumulkkum.server.service.member.MemberSaver;
 import org.kkumulkkum.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +49,11 @@ public class MeetingService {
                 .user(userRetriever.findById(userId))
                 .build();
         memberSaver.save(member);
+    }
+
+    public MeetingsDto getMeetings(Long userId) {
+        List<Meeting> meetings = meetingRetriever.findAllByUserId(userId);
+        return MeetingsDto.of(meetings);
     }
 
     private String generateInvitationCode() {

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.domain.Meeting;
 import org.kkumulkkum.server.domain.Member;
 import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
+import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
 import org.kkumulkkum.server.service.member.MemberSaver;
 import org.kkumulkkum.server.service.user.UserRetriever;
@@ -39,6 +40,15 @@ public class MeetingService {
         return new CreatedMeetingDto(meeting.getId(), meeting.getInvitationCode());
     }
 
+    public void registerMeeting(Long userId, MeetingRegisterDto meetingRegisterDto) {
+        Meeting meeting = meetingRetriever.findByInvitationCode(meetingRegisterDto.invitationCode());
+        Member member = Member.builder()
+                .meeting(meeting)
+                .user(userRetriever.findById(userId))
+                .build();
+        memberSaver.save(member);
+    }
+
     private String generateInvitationCode() {
         String invitationCode;
 
@@ -61,4 +71,5 @@ public class MeetingService {
 
         return codeBuilder.toString();
     }
+
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
@@ -1,7 +1,64 @@
 package org.kkumulkkum.server.service.meeting;
 
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Meeting;
+import org.kkumulkkum.server.domain.Member;
+import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
+import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
+import org.kkumulkkum.server.service.member.MemberSaver;
+import org.kkumulkkum.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+
 @Service
+@RequiredArgsConstructor
 public class MeetingService {
+
+    private final MeetingSaver meetingSaver;
+    private final MeetingRetriever meetingRetriever;
+    private final UserRetriever userRetriever;
+    private final MemberSaver memberSaver;
+
+    public CreatedMeetingDto createMeeting(
+            Long userId, MeetingCreateDto meetingCreateDto
+    ) {
+        String invitationCode = generateInvitationCode();
+
+        Meeting meeting = Meeting.builder()
+                .name(meetingCreateDto.name())
+                .invitationCode(invitationCode)
+                .build();
+        meetingSaver.save(meeting);
+
+        memberSaver.save(Member.builder()
+                .meeting(meeting)
+                .user(userRetriever.findById(userId))
+                .build());
+
+        return new CreatedMeetingDto(meeting.getId(), meeting.getInvitationCode());
+    }
+
+    private String generateInvitationCode() {
+        String invitationCode;
+
+        do {
+            invitationCode = generateRandomCode();
+        } while (meetingRetriever.existsByInvitationCode(invitationCode));
+
+        return invitationCode;
+    }
+
+    private String generateRandomCode() {
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder codeBuilder = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            int index = random.nextInt(characters.length());
+            codeBuilder.append(characters.charAt(index));
+        }
+
+        return codeBuilder.toString();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
+++ b/src/main/java/org/kkumulkkum/server/service/meeting/MeetingService.java
@@ -7,6 +7,9 @@ import org.kkumulkkum.server.dto.meeting.request.MeetingCreateDto;
 import org.kkumulkkum.server.dto.meeting.request.MeetingRegisterDto;
 import org.kkumulkkum.server.dto.meeting.response.CreatedMeetingDto;
 import org.kkumulkkum.server.dto.meeting.response.MeetingsDto;
+import org.kkumulkkum.server.exception.MeetingException;
+import org.kkumulkkum.server.exception.code.MeetingErrorCode;
+import org.kkumulkkum.server.service.member.MemberRetreiver;
 import org.kkumulkkum.server.service.member.MemberSaver;
 import org.kkumulkkum.server.service.user.UserRetriever;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,7 @@ public class MeetingService {
     private final MeetingRetriever meetingRetriever;
     private final UserRetriever userRetriever;
     private final MemberSaver memberSaver;
+    private final MemberRetreiver memberRetreiver;
 
     public CreatedMeetingDto createMeeting(
             Long userId, MeetingCreateDto meetingCreateDto
@@ -48,6 +52,9 @@ public class MeetingService {
                 .meeting(meeting)
                 .user(userRetriever.findById(userId))
                 .build();
+        if (memberRetreiver.existsByMeetingIdAndUserId(meeting.getId(), userId)) {
+            throw new MeetingException(MeetingErrorCode.ALREADY_JOINED);
+        }
         memberSaver.save(member);
     }
 

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
@@ -1,8 +1,13 @@
 package org.kkumulkkum.server.service.member;
 
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Member;
+import org.kkumulkkum.server.dto.member.MemberUserInfoDto;
+import org.kkumulkkum.server.dto.member.response.MemberDto;
 import org.kkumulkkum.server.repository.MemberRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -12,5 +17,9 @@ public class MemberRetreiver {
 
     public boolean existsByMeetingIdAndUserId(Long meetingId, Long userId) {
         return memberRepository.existsByMeetingIdAndUserId(meetingId, userId);
+    }
+
+    public List<MemberUserInfoDto> findAllByMeetingId(Long meetingId) {
+        return memberRepository.findAllByMeetingId(meetingId);
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.service.member;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.MemberRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRetreiver {
+
+    private final MemberRepository memberRepository;
+
+    public boolean existsByMeetingIdAndUserId(Long meetingId, Long userId) {
+        return memberRepository.existsByMeetingIdAndUserId(meetingId, userId);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberSaver.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.service.member;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Member;
+import org.kkumulkkum.server.repository.MemberRepository;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class MemberSaver {
+
+    private final MemberRepository memberRepository;
+    
+    public void save(final Member member) {
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/user/UserRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/user/UserRetriever.java
@@ -1,0 +1,20 @@
+package org.kkumulkkum.server.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.exception.UserException;
+import org.kkumulkkum.server.exception.code.UserErrorCode;
+import org.kkumulkkum.server.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRetriever {
+
+    private final UserRepository userRepository;
+
+    public User findById(final Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #16

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Meeting 도메인과 관련된 API들을 제작 완료했습니다.
- 기본 이미지의 경우 클라이언트가 null이 아닌 기본 imgUrl을 요청해서 해당 작업을 진행해보았습니다.
- 다만 기본 이미지의 url이 노출될 경우 S3 보안에 문제가 있을 수 있다 판단하여 yml 파일로 내용을 빼두었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)