### PR TITLE
[feat] 소셜 로그인 로그아웃, jwt 토큰 reissue 구현

### DIFF
--- a/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITE_LIST = {
             "/api/v1/test/**",
             "/api/v1/auth/signin",
+            "/api/v1/auth/reissue",
             "/actuator/health",
     };
 

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -27,11 +27,11 @@ public class AuthController {
     }
 
 
-    @PostMapping("/auth/logout")
-    public ResponseEntity<Void> logout(
+    @PostMapping("/auth/signout")
+    public ResponseEntity<Void> signout(
             @UserId final Long userId
     ) {
-        authService.logout(userId);
+        authService.signout(userId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -3,6 +3,7 @@ package org.kkumulkkum.server.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.constant.Constant;
 import org.kkumulkkum.server.dto.auth.request.UserLoginDto;
 import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
@@ -23,6 +24,15 @@ public class AuthController {
             @Valid @RequestBody final UserLoginDto userLoginDto
     ) {
         return ResponseEntity.ok(authService.signin(providerToken, userLoginDto));
+    }
+
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Void> logout(
+            @UserId final Long userId
+    ) {
+        authService.logout(userId);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/auth/reissue")

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -25,4 +25,11 @@ public class AuthController {
         return ResponseEntity.ok(authService.signin(providerToken, userLoginDto));
     }
 
+    @PostMapping("/auth/reissue")
+    public ResponseEntity<JwtTokenDto> reissue(
+            @NotNull @RequestHeader(Constant.AUTHORIZATION_HEADER) final String refreshToken
+    ) {
+        return ResponseEntity.ok(authService.reissue(refreshToken));
+    }
+
 }

--- a/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
@@ -1,8 +1,10 @@
 package org.kkumulkkum.server.dto.auth.request;
 
+import jakarta.validation.constraints.NotNull;
 import org.kkumulkkum.server.domain.enums.Provider;
 
 public record UserLoginDto(
+        @NotNull
         Provider provider
 ) {
 }

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -22,6 +22,9 @@ public enum AuthErrorCode implements DefaultErrorCode {
     EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, 40194, "토큰이 제공되지 않았습니다."),
     MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40195, "리프레시 토큰이 일치하지 않습니다."),
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED, 40196, "알 수 없는 토큰입니다."),
+
+    // 404 Not Found
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, 40490, "존재하지 않는 리프레시 토큰입니다."),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/org/kkumulkkum/server/repository/TokenRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/TokenRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface TokenRepository extends CrudRepository<Token, Long> {
 
-    Optional<Token> findIdByRefreshToken(String refreshToken);
+    Optional<Token> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(final Long userId) {
+    public void signout(final Long userId) {
         tokenRemover.removeById(userId);
     }
 

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -84,6 +84,7 @@ public class AuthService {
 
             UserInfo newUserInfo = UserInfo.builder()
                     .email(socialUserDto.email())
+                    .user(newUser)
                     .build();
 
             userSaver.save(newUser);

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -31,18 +31,28 @@ public class AuthService {
     private final UserInfoSaver userInfoSaver;
     private final TokenSaver tokenSaver;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRetriever tokenRetriever;
 
     @Transactional
     public JwtTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
         SocialUserDto socialUserDto = getSocialInfo(providerToken, userLoginDto);
         User user = loadOrCreateUser(userLoginDto.provider(), socialUserDto);
         JwtTokenDto tokens = jwtTokenProvider.issueTokens(user.getId());
-        tokenSaver.save(
-                Token.builder()
-                        .id(user.getId())
-                        .refreshToken(tokens.refreshToken())
-                        .build()
-        );
+        saveToken(user.getId(), tokens);
+        return tokens;
+    }
+
+    @Transactional
+    public JwtTokenDto reissue(final String refreshToken) {
+        Long userId = jwtTokenProvider.getUserIdFromJwt(refreshToken);
+        Token token = tokenRetriever.findByRefreshToken(refreshToken);
+
+        if(!userId.equals(token.getId())) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        JwtTokenDto tokens = jwtTokenProvider.issueTokens(userId);
+        saveToken(userId, tokens);
         return tokens;
     }
 
@@ -75,5 +85,14 @@ public class AuthService {
         }
 
         return userRetriever.findByProviderIdAndProvider(socialUserDto.platformId(), provider);
+    }
+
+    private void saveToken(final Long userId, final JwtTokenDto tokens) {
+        tokenSaver.save(
+                Token.builder()
+                        .id(userId)
+                        .refreshToken(tokens.refreshToken())
+                        .build()
+        );
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -32,6 +32,7 @@ public class AuthService {
     private final TokenSaver tokenSaver;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenRetriever tokenRetriever;
+    private final TokenRemover tokenRemover;
 
     @Transactional
     public JwtTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
@@ -40,6 +41,11 @@ public class AuthService {
         JwtTokenDto tokens = jwtTokenProvider.issueTokens(user.getId());
         saveToken(user.getId(), tokens);
         return tokens;
+    }
+
+    @Transactional
+    public void logout(final Long userId) {
+        tokenRemover.removeById(userId);
     }
 
     @Transactional

--- a/src/main/java/org/kkumulkkum/server/service/auth/TokenRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/TokenRemover.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.TokenRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenRemover {
+
+    private final TokenRepository tokenRepository;
+
+    public void removeById(final Long id) {
+        tokenRepository.deleteById(id);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/auth/TokenRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/TokenRetriever.java
@@ -1,0 +1,20 @@
+package org.kkumulkkum.server.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Token;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.kkumulkkum.server.repository.TokenRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenRetriever {
+
+    private final TokenRepository tokenRepository;
+
+    public Token findByRefreshToken(String refreshToken) {
+        return tokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND_REFRESH_TOKEN));
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/auth/TokenRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/TokenRetriever.java
@@ -13,7 +13,7 @@ public class TokenRetriever {
 
     private final TokenRepository tokenRepository;
 
-    public Token findByRefreshToken(String refreshToken) {
+    public Token findByRefreshToken(final String refreshToken) {
         return tokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND_REFRESH_TOKEN));
     }

--- a/src/main/java/org/kkumulkkum/server/service/auth/TokenSaver.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/TokenSaver.java
@@ -11,8 +11,8 @@ public class TokenSaver {
 
     private final TokenRepository tokenRepository;
 
-    public Token save(final Token token){
-        return tokenRepository.save(token);
+    public void save(final Token token){
+        tokenRepository.save(token);
     }
 
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #20 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 소셜 로그인 로그아웃 로직 구현했습니다. (리프레시 토큰 삭제)
- jwt 토큰 reissue(재발급) 로직 구현했습니다. (재발급 시에 AT, RT 모두 재발급할 수 있도록)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
https://github.com/OMZigak/KKUM_SERVER/blob/d848599e1ce1bdf7350ec9a321e8a3af5fd100ce/src/main/java/org/kkumulkkum/server/controller/AuthController.java#L30-L36

여기서 `return ResponseEntity.ok().build(); ` 를 하는 경우도 있고, `return ResponseEntity.noContent().build(); ` 를 해주는 경우가 있던데, 무엇으로 하는 것이 더 좋을지 고민이 됩니다.