### PR TITLE
[feat] 참여자 도메인 API 일부 생성

### DIFF
--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -4,9 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.kkumulkkum.server.exception.AuthException;
 import org.kkumulkkum.server.exception.BusinessException;
 import org.kkumulkkum.server.exception.MeetingException;
+import org.kkumulkkum.server.exception.ParticipantException;
 import org.kkumulkkum.server.exception.code.AuthErrorCode;
 import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.kkumulkkum.server.exception.code.MeetingErrorCode;
+import org.kkumulkkum.server.exception.code.ParticipantErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -29,6 +31,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {AuthException.class})
     public ResponseEntity<AuthErrorCode> handleAuthException(AuthException e) {
         log.error("GlobalExceptionHandler catch AuthException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    @ExceptionHandler(value = {ParticipantException.class})
+    public ResponseEntity<ParticipantErrorCode> handleParticipantException(ParticipantException e) {
+        log.error("GlobalExceptionHandler catch ParticipantException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());

--- a/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
@@ -1,0 +1,46 @@
+package org.kkumulkkum.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.UserId;
+import org.kkumulkkum.server.service.participant.ParticipantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @PatchMapping("/promises/{promiseId}/preperation")
+    public ResponseEntity<Void> preparePromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.preparePromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/promises/{promiseId}/departure")
+    public ResponseEntity<Void> departurePromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.departurePromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/promises/{promiseId}/arrival")
+    public ResponseEntity<Void> arrivalPromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.arrivalPromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -1,0 +1,28 @@
+package org.kkumulkkum.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.UserId;
+import org.kkumulkkum.server.service.participant.ParticipantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PromiseController {
+
+    private final ParticipantService participantService;
+
+    @PatchMapping("/promises/{promiseId}/preperation")
+    public ResponseEntity<Void> preparePromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.preparePromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -25,4 +25,13 @@ public class PromiseController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/promises/{promiseId}/departure")
+    public ResponseEntity<Void> departurePromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.departurePromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -34,4 +34,13 @@ public class PromiseController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/promises/{promiseId}/arrival")
+    public ResponseEntity<Void> arrivalPromise(
+            @UserId Long userId,
+            @PathVariable Long promiseId
+    ) {
+        participantService.arrivalPromise(userId, promiseId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -1,11 +1,6 @@
 package org.kkumulkkum.server.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.kkumulkkum.server.annotation.UserId;
-import org.kkumulkkum.server.service.participant.ParticipantService;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,34 +8,5 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class PromiseController {
-
-    private final ParticipantService participantService;
-
-    @PatchMapping("/promises/{promiseId}/preperation")
-    public ResponseEntity<Void> preparePromise(
-            @UserId Long userId,
-            @PathVariable Long promiseId
-    ) {
-        participantService.preparePromise(userId, promiseId);
-        return ResponseEntity.ok().build();
-    }
-
-    @PatchMapping("/promises/{promiseId}/departure")
-    public ResponseEntity<Void> departurePromise(
-            @UserId Long userId,
-            @PathVariable Long promiseId
-    ) {
-        participantService.departurePromise(userId, promiseId);
-        return ResponseEntity.ok().build();
-    }
-
-    @PatchMapping("/promises/{promiseId}/arrival")
-    public ResponseEntity<Void> arrivalPromise(
-            @UserId Long userId,
-            @PathVariable Long promiseId
-    ) {
-        participantService.arrivalPromise(userId, promiseId);
-        return ResponseEntity.ok().build();
-    }
 
 }

--- a/src/main/java/org/kkumulkkum/server/domain/Participant.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Participant.java
@@ -56,4 +56,8 @@ public class Participant extends BaseTimeEntity {
     public void preparePromise() {
         this.preparationStartAt = LocalDateTime.now();
     }
+
+    public void departurePromise() {
+        this.departureAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/domain/Participant.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Participant.java
@@ -60,4 +60,8 @@ public class Participant extends BaseTimeEntity {
     public void departurePromise() {
         this.departureAt = LocalDateTime.now();
     }
+
+    public void arrivalPromise() {
+        this.arrivalAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/domain/Participant.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Participant.java
@@ -52,4 +52,8 @@ public class Participant extends BaseTimeEntity {
         this.promise = promise;
         this.member = member;
     }
+
+    public void preparePromise() {
+        this.preparationStartAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/exception/ParticipantException.java
+++ b/src/main/java/org/kkumulkkum/server/exception/ParticipantException.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.exception.code.ParticipantErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class ParticipantException extends RuntimeException {
+    private final ParticipantErrorCode errorCode;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/ParticipantErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/ParticipantErrorCode.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ParticipantErrorCode implements DefaultErrorCode{
+    // 400 BAD_REQUEST
+    NOT_JOINED_PROMISE(HttpStatus.BAD_REQUEST, 40040, "참여하지 않은 약속입니다."),
+    INVALID_STATE(HttpStatus.BAD_REQUEST, 40041, "유효하지 않은 상태 변경입니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
@@ -2,6 +2,14 @@ package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+    @Query("SELECT p FROM Participant p " +
+            "JOIN Member m ON p.member.id = m.id " +
+            "WHERE p.promise.id = :promiseId AND m.user.id = :userId")
+    Optional<Participant> findByPromiseIdAndUserId(Long promiseId, Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
@@ -15,4 +15,8 @@ public class ParticipantEditor {
     public void departurePromise(final Participant participant) {
         participant.departurePromise();
     }
+
+    public void arrivalPromise(final Participant participant) {
+        participant.arrivalPromise();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
@@ -1,0 +1,14 @@
+package org.kkumulkkum.server.service.participant;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Participant;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantEditor {
+
+    public void preparePromise(final Participant participant) {
+        participant.preparePromise();
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantEditor.java
@@ -11,4 +11,8 @@ public class ParticipantEditor {
     public void preparePromise(final Participant participant) {
         participant.preparePromise();
     }
+
+    public void departurePromise(final Participant participant) {
+        participant.departurePromise();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRetriever.java
@@ -1,0 +1,20 @@
+package org.kkumulkkum.server.service.participant;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Participant;
+import org.kkumulkkum.server.exception.ParticipantException;
+import org.kkumulkkum.server.exception.code.ParticipantErrorCode;
+import org.kkumulkkum.server.repository.ParticipantRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantRetriever {
+
+    private final ParticipantRepository participantRepository;
+
+    public Participant findByPromiseIdAndUserId(Long promiseId, Long userId) {
+        return participantRepository.findByPromiseIdAndUserId(promiseId, userId)
+                .orElseThrow(() -> new ParticipantException(ParticipantErrorCode.NOT_JOINED_PROMISE));
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -1,7 +1,57 @@
 package org.kkumulkkum.server.service.participant;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kkumulkkum.server.domain.Participant;
+import org.kkumulkkum.server.exception.ParticipantException;
+import org.kkumulkkum.server.exception.code.ParticipantErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class ParticipantService {
+
+    private final ParticipantRetriever participantRetriever;
+    private final ParticipantEditor participantEditor;
+
+    @Transactional
+    public void preparePromise(final Long userId, final Long promiseId) {
+        Participant participant = participantRetriever.findByPromiseIdAndUserId(promiseId, userId);
+        if (!validateState(participant, "preperation")) {
+            throw new ParticipantException(ParticipantErrorCode.INVALID_STATE);
+        }
+        participantEditor.preparePromise(participant);
+    }
+
+    private boolean validateState(final Participant participant, final String status) {
+        switch (status) {
+            case "preperation":
+                return isNull(participant.getPreparationStartAt())
+                        && isNull(participant.getDepartureAt())
+                        && isNull(participant.getArrivalAt());
+            case "departure":
+                return isNotNull(participant.getPreparationStartAt())
+                        && isNull(participant.getDepartureAt())
+                        && isNull(participant.getArrivalAt());
+            case "arrival":
+                return isNotNull(participant.getPreparationStartAt())
+                        && isNotNull(participant.getDepartureAt())
+                        && isNull(participant.getArrivalAt());
+            default:
+                throw new IllegalArgumentException("Unknown status");
+        }
+    }
+
+    private boolean isNull(LocalDateTime time) {
+        return time == null;
+    }
+
+    private boolean isNotNull(LocalDateTime time) {
+        return time != null;
+    }
+
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -27,6 +27,15 @@ public class ParticipantService {
         participantEditor.preparePromise(participant);
     }
 
+    @Transactional
+    public void departurePromise(final Long userId, final Long promiseId) {
+        Participant participant = participantRetriever.findByPromiseIdAndUserId(promiseId, userId);
+        if (!validateState(participant, "departure")) {
+            throw new ParticipantException(ParticipantErrorCode.INVALID_STATE);
+        }
+        participantEditor.departurePromise(participant);
+    }
+
     private boolean validateState(final Participant participant, final String status) {
         switch (status) {
             case "preperation":

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -36,6 +36,15 @@ public class ParticipantService {
         participantEditor.departurePromise(participant);
     }
 
+    @Transactional
+    public void arrivalPromise(final Long userId, final Long promiseId) {
+        Participant participant = participantRetriever.findByPromiseIdAndUserId(promiseId, userId);
+        if (!validateState(participant, "arrival")) {
+            throw new ParticipantException(ParticipantErrorCode.INVALID_STATE);
+        }
+        participantEditor.arrivalPromise(participant);
+    }
+
     private boolean validateState(final Participant participant, final String status) {
         switch (status) {
             case "preperation":


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #24

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Participant 엔티티 관련 도메인 중 시간 업데이트 API들을 제작 완료했습니다.
- 이전 상태가 완료되지 않았을 때 다음 상태를 업데이트하지 못하도록 검증하는 로직이 있습니다.
https://github.com/OMZigak/KKUM_SERVER/blob/55b64258967a97de61f169622144931551001f69/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java#L48-L73

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)