### PR TITLE
[feat] 사용자 프로필 관련 API 생성 (S3 Multipart 관련)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// AWS S3
+	implementation("software.amazon.awssdk:bom:2.21.0")
+	implementation("software.amazon.awssdk:s3:2.21.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -2,9 +2,11 @@ package org.kkumulkkum.server.advice;
 
 import lombok.extern.slf4j.Slf4j;
 import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.AwsException;
 import org.kkumulkkum.server.exception.BusinessException;
 import org.kkumulkkum.server.exception.MeetingException;
 import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.kkumulkkum.server.exception.code.AwsErrorCode;
 import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.kkumulkkum.server.exception.code.MeetingErrorCode;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
@@ -29,6 +32,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {AuthException.class})
     public ResponseEntity<AuthErrorCode> handleAuthException(AuthException e) {
         log.error("GlobalExceptionHandler catch AuthException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    @ExceptionHandler(value = {AwsException.class})
+    public ResponseEntity<AwsErrorCode> handleAwsException(AwsException e) {
+        log.error("GlobalExceptionHandler catch AwsException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -58,6 +69,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(BusinessErrorCode.INVALID_ARGUMENTS.getHttpStatus())
                 .body(BusinessErrorCode.INVALID_ARGUMENTS);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<BusinessErrorCode> handleMaxSizeException(MaxUploadSizeExceededException e) {
+        return ResponseEntity
+                .status(BusinessErrorCode.PAYLOAD_TOO_LARGE.getHttpStatus())
+                .body(BusinessErrorCode.PAYLOAD_TOO_LARGE);
     }
 
     // 기본 예외

--- a/src/main/java/org/kkumulkkum/server/config/AwsConfig.java
+++ b/src/main/java/org/kkumulkkum/server/config/AwsConfig.java
@@ -1,0 +1,47 @@
+package org.kkumulkkum.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String regionString;
+
+    public AwsConfig(@Value("${aws-property.access-key}") final String accessKey,
+                     @Value("${aws-property.secret-key}") final String secretKey,
+                     @Value("${aws-property.aws-region}") final String regionString) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.regionString = regionString;
+    }
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(regionString);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/controller/UserController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/UserController.java
@@ -1,0 +1,51 @@
+package org.kkumulkkum.server.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.UserId;
+import org.kkumulkkum.server.dto.user.request.ImageUpdateDto;
+import org.kkumulkkum.server.dto.user.response.UserDto;
+import org.kkumulkkum.server.dto.user.response.UserNameDto;
+import org.kkumulkkum.server.service.user.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/users/me/image")
+    public ResponseEntity<Void> updateImage(
+            @UserId final Long userId,
+            @Valid @ModelAttribute final ImageUpdateDto imageUpdateDto
+    ) {
+        userService.updateImage(userId, imageUpdateDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/users/me/image")
+    public ResponseEntity<Void> deleteImage(
+            @UserId final Long userId
+    ) {
+        userService.deleteImage(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/users/me/name")
+    public ResponseEntity<UserNameDto> updateName(
+            @UserId final Long userId,
+            @Valid @RequestBody final UserNameDto userNameDto
+    ) {
+        return ResponseEntity.ok().body(userService.updateName(userId, userNameDto));
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<UserDto> getUserInfo(
+            @UserId final Long userId
+    ) {
+        return ResponseEntity.ok().body(userService.getUserInfo(userId));
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
+++ b/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
@@ -47,4 +47,16 @@ public class UserInfo extends BaseTimeEntity {
         this.user = user;
         this.tardySum = 0L;
     }
+
+    public void updateImage(String imageUrl) {
+        this.profileImg = imageUrl;
+    }
+
+    public void deleteImage() {
+        this.profileImg = null;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/dto/user/request/ImageUpdateDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/user/request/ImageUpdateDto.java
@@ -1,0 +1,10 @@
+package org.kkumulkkum.server.dto.user.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUpdateDto(
+        @NotNull
+        MultipartFile image
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/dto/user/request/NameUpdateDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/user/request/NameUpdateDto.java
@@ -1,0 +1,10 @@
+package org.kkumulkkum.server.dto.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NameUpdateDto(
+        @NotBlank @Size(max = 5)
+        String name
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/dto/user/response/UserDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/user/response/UserDto.java
@@ -1,0 +1,23 @@
+package org.kkumulkkum.server.dto.user.response;
+
+import org.kkumulkkum.server.domain.UserInfo;
+
+public record UserDto(
+        String name,
+        int level,
+        int promiseCount,
+        int tardyCount,
+        Long tardySum,
+        String profileImg
+) {
+    public static UserDto from(UserInfo userInfo) {
+        return new UserDto(
+                userInfo.getName(),
+                userInfo.getLevel(),
+                userInfo.getPromiseCount(),
+                userInfo.getTardyCount(),
+                userInfo.getTardySum(),
+                userInfo.getProfileImg()
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/user/response/UserNameDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/user/response/UserNameDto.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.dto.user.response;
+
+import org.kkumulkkum.server.domain.UserInfo;
+
+public record UserNameDto(
+        String name
+) {
+    public static UserNameDto from(UserInfo userInfo) {
+        return new UserNameDto(userInfo.getName());
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/exception/AwsException.java
+++ b/src/main/java/org/kkumulkkum/server/exception/AwsException.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.exception.code.AwsErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class AwsException extends RuntimeException {
+    private final AwsErrorCode errorCode;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/AwsErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AwsErrorCode.java
@@ -1,0 +1,21 @@
+package org.kkumulkkum.server.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AwsErrorCode implements DefaultErrorCode {
+    // 400 Bad Request
+    INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, 40080, "이미지 확장자는 jpg, png, webp만 가능합니다."),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST,40081, "이미지 사이즈는 5MB를 넘을 수 없습니다."),
+
+    // 404 Not Found
+    NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, 40480, "삭제할 이미지를 찾을 수 없습니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/BusinessErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/BusinessErrorCode.java
@@ -10,6 +10,7 @@ public enum BusinessErrorCode implements DefaultErrorCode {
     // 400 Bad Request
     BAD_REQUEST(HttpStatus.BAD_REQUEST,40000, "잘못된 요청입니다."),
     INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, 40001, "인자의 형식이 올바르지 않습니다."),
+    PAYLOAD_TOO_LARGE(HttpStatus.BAD_REQUEST,40002,"최대 업로드 크기를 초과했습니다."),
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND,40400, "요청한 정보를 찾을 수 없습니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND,40401, "요청한 엔드포인트를 찾을 수 없습니다."),

--- a/src/main/java/org/kkumulkkum/server/external/S3Service.java
+++ b/src/main/java/org/kkumulkkum/server/external/S3Service.java
@@ -1,0 +1,83 @@
+package org.kkumulkkum.server.external;
+
+import org.kkumulkkum.server.config.AwsConfig;
+import org.kkumulkkum.server.exception.AwsException;
+import org.kkumulkkum.server.exception.code.AwsErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class S3Service {
+
+    private final String bucketName;
+    private final AwsConfig awsConfig;
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+    public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AwsConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        final String extension = getFileExtension(image.getOriginalFilename());
+        final String key = directoryPath + generateImageFileName(extension);
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return key;
+    }
+
+    public void deleteImage(String key) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
+                builder.bucket(bucketName)
+                        .key(key)
+                        .build()
+        );
+    }
+
+    private String getFileExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf(".") + 1);
+    }
+
+    private String generateImageFileName(String extension) {
+        return UUID.randomUUID() + "." + extension;
+    }
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new AwsException(AwsErrorCode.INVALID_IMAGE_EXTENSION);
+        }
+    }
+
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new AwsException(AwsErrorCode.IMAGE_SIZE_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/repository/UserInfoRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/UserInfoRepository.java
@@ -3,5 +3,9 @@ package org.kkumulkkum.server.repository;
 import org.kkumulkkum.server.domain.UserInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
+
+    Optional<UserInfo> findByUserId(Long id);
 }

--- a/src/main/java/org/kkumulkkum/server/service/user/UserService.java
+++ b/src/main/java/org/kkumulkkum/server/service/user/UserService.java
@@ -1,7 +1,83 @@
 package org.kkumulkkum.server.service.user;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kkumulkkum.server.domain.UserInfo;
+import org.kkumulkkum.server.dto.user.request.ImageUpdateDto;
+import org.kkumulkkum.server.dto.user.response.UserDto;
+import org.kkumulkkum.server.dto.user.response.UserNameDto;
+import org.kkumulkkum.server.exception.AwsException;
+import org.kkumulkkum.server.exception.code.AwsErrorCode;
+import org.kkumulkkum.server.external.S3Service;
+import org.kkumulkkum.server.service.userInfo.UserInfoRetriever;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserInfoRetriever userInfoRetriever;
+    private final S3Service s3Service;
+    static final String PROFILE_S3_UPLOAD_FOLDER = "profile/";
+
+    @Transactional
+    public void updateImage(
+            final Long userId, final ImageUpdateDto imageUpdateDto
+    ) {
+        UserInfo userInfo = userInfoRetriever.findByUserId(userId);
+
+        if (userInfo.getProfileImg() != null) {
+            try {
+                s3Service.deleteImage(userInfo.getProfileImg());
+            } catch (AwsException e) {
+                throw new AwsException(e.getErrorCode());
+            } catch (RuntimeException | IOException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }
+
+        try {
+            userInfo.updateImage(s3Service.uploadImage(PROFILE_S3_UPLOAD_FOLDER, imageUpdateDto.image()));
+        } catch (AwsException e) {
+            throw new AwsException(e.getErrorCode());
+        } catch (RuntimeException | IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Transactional
+    public void deleteImage(final Long userId) {
+        UserInfo userInfo = userInfoRetriever.findByUserId(userId);
+
+        if (userInfo.getProfileImg() == null) {
+            throw new AwsException(AwsErrorCode.NOT_FOUND_IMAGE);
+        }
+
+        try {
+            s3Service.deleteImage(userInfo.getProfileImg());
+        } catch (AwsException e) {
+            throw new AwsException(e.getErrorCode());
+        } catch (RuntimeException | IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        userInfo.deleteImage();
+    }
+
+    @Transactional
+    public UserNameDto updateName(final Long userId, final UserNameDto userNameDto) {
+        UserInfo userInfo = userInfoRetriever.findByUserId(userId);
+        userInfo.updateName(userNameDto.name());
+
+        return UserNameDto.from(userInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public UserDto getUserInfo(final Long userId) {
+        UserInfo userInfo = userInfoRetriever.findByUserId(userId);
+        return UserDto.from(userInfo);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRetriever.java
@@ -1,4 +1,20 @@
 package org.kkumulkkum.server.service.userInfo;
 
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.UserInfo;
+import org.kkumulkkum.server.exception.UserException;
+import org.kkumulkkum.server.exception.code.UserErrorCode;
+import org.kkumulkkum.server.repository.UserInfoRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class UserInfoRetriever {
+
+    private final UserInfoRepository userInfoRepository;
+
+    public UserInfo findByUserId(final Long id) {
+        return userInfoRepository.findByUserId(id)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoService.java
+++ b/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoService.java
@@ -1,7 +1,0 @@
-package org.kkumulkkum.server.service.userInfo;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class UserInfoService {
-}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #23 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- S3 클라우드 서비스를 이용하여 사용자의 프로필을 저장 및 삭제할 수 있도록 했습니다.
- 사용자 프로필 관련 API를 생성했습니다. (로그인한 유저 정보 조회, 사용자 프로필 사진 수정 및 삭제, 사용자 이름 수정)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)