### PR TITLE
[feat] 권한 확인 Annotation 제작

### DIFF
--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -47,6 +47,14 @@ public class GlobalExceptionHandler {
                 .body(e.getErrorCode());
     }
 
+    @ExceptionHandler(value = {MemberException.class})
+    public ResponseEntity<MemberErrorCode> handleMemberException(MemberException e) {
+        log.error("GlobalExceptionHandler catch MemberException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
     @ExceptionHandler(value = {AwsException.class})
     public ResponseEntity<AwsErrorCode> handleAwsException(AwsException e) {
         log.error("GlobalExceptionHandler catch AwsException : {}", e.getErrorCode().getMessage());

--- a/src/main/java/org/kkumulkkum/server/annotation/IsMember.java
+++ b/src/main/java/org/kkumulkkum/server/annotation/IsMember.java
@@ -1,0 +1,12 @@
+package org.kkumulkkum.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface IsMember {
+    long meetingIdParamIndex();
+}

--- a/src/main/java/org/kkumulkkum/server/annotation/IsMember.java
+++ b/src/main/java/org/kkumulkkum/server/annotation/IsMember.java
@@ -8,5 +8,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface IsMember {
-    long meetingIdParamIndex();
+    long meetingIdParamIndex() default -1;
+    long promiseIdParamIndex() default -1;
 }

--- a/src/main/java/org/kkumulkkum/server/annotation/IsParticipant.java
+++ b/src/main/java/org/kkumulkkum/server/annotation/IsParticipant.java
@@ -1,0 +1,12 @@
+package org.kkumulkkum.server.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface IsParticipant {
+    long promiseIdParamIndex();
+}

--- a/src/main/java/org/kkumulkkum/server/aspect/MemberCheckAspect.java
+++ b/src/main/java/org/kkumulkkum/server/aspect/MemberCheckAspect.java
@@ -1,0 +1,31 @@
+package org.kkumulkkum.server.aspect;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.kkumulkkum.server.annotation.IsMember;
+import org.kkumulkkum.server.exception.MemberException;
+import org.kkumulkkum.server.exception.code.MemberErrorCode;
+import org.kkumulkkum.server.service.member.MemberRetreiver;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MemberCheckAspect {
+
+    private final MemberRetreiver memberRetreiver;
+
+    @Before("@annotation(checkUserInMeeting)")
+    public void checkUserInMeeting(JoinPoint joinPoint, IsMember checkUserInMeeting) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        Long meetingId = (Long) args[(int) checkUserInMeeting.meetingIdParamIndex()];
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId)) {
+            throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/aspect/MemberCheckAspect.java
+++ b/src/main/java/org/kkumulkkum/server/aspect/MemberCheckAspect.java
@@ -22,10 +22,18 @@ public class MemberCheckAspect {
     public void checkUserInMeeting(JoinPoint joinPoint, IsMember checkUserInMeeting) throws Throwable {
         Object[] args = joinPoint.getArgs();
         Long meetingId = (Long) args[(int) checkUserInMeeting.meetingIdParamIndex()];
+        Long promiseId = (Long) args[(int) checkUserInMeeting.promiseIdParamIndex()];
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        if (!memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId)) {
-            throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+        if (meetingId != -1) {
+            if (!memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId)) {
+                throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+            }
+        }
+        if (promiseId != -1) {
+            if (!memberRetreiver.existsByPromiseIdAndUserId(promiseId, userId)) {
+                throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+            }
         }
     }
 }

--- a/src/main/java/org/kkumulkkum/server/aspect/ParticipantCheckAspect.java
+++ b/src/main/java/org/kkumulkkum/server/aspect/ParticipantCheckAspect.java
@@ -1,0 +1,31 @@
+package org.kkumulkkum.server.aspect;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.kkumulkkum.server.annotation.IsParticipant;
+import org.kkumulkkum.server.exception.MemberException;
+import org.kkumulkkum.server.exception.code.MemberErrorCode;
+import org.kkumulkkum.server.service.participant.ParticipantRetriever;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ParticipantCheckAspect {
+
+    private final ParticipantRetriever participantRetriever;
+
+    @Before("@annotation(checkUserInPromise)")
+    public void checkUserInMeeting(JoinPoint joinPoint, IsParticipant checkUserInPromise) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        Long promiseId = (Long) args[(int) checkUserInPromise.promiseIdParamIndex()];
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!participantRetriever.existsByPromiseIdAndUserId(promiseId, userId)) {
+            throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+        }
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
@@ -1,6 +1,7 @@
 package org.kkumulkkum.server.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.IsMember;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.participant.request.PreparationInfoDto;
 import org.kkumulkkum.server.dto.participant.response.LateComersDto;
@@ -52,12 +53,12 @@ public class ParticipantController {
         return ResponseEntity.ok().body(participantService.getPreparation(userId, promiseId));
     }
 
+    @IsMember(promiseIdParamIndex = 0)
     @GetMapping("/promises/{promiseId}/participants")
     public ResponseEntity<ParticipantsDto> getParticipants(
-            @UserId final Long userId,
             @PathVariable("promiseId") final Long promiseId
     ) {
-        return ResponseEntity.ok().body(participantService.getParticipants(userId, promiseId));
+        return ResponseEntity.ok().body(participantService.getParticipants(promiseId));
     }
 
     @PatchMapping("/promises/{promiseId}/times")
@@ -70,11 +71,11 @@ public class ParticipantController {
         return ResponseEntity.ok().build();
     }
 
+    @IsMember(promiseIdParamIndex = 0)
     @GetMapping("/promises/{promiseId}/tardy")
     public ResponseEntity<LateComersDto> getLateComers(
-            @UserId final Long userId,
             @PathVariable("promiseId") final Long promiseId
     ) {
-        return ResponseEntity.ok().body(participantService.getLateComers(userId, promiseId));
+        return ResponseEntity.ok().body(participantService.getLateComers(promiseId));
     }
 }

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -2,6 +2,7 @@ package org.kkumulkkum.server.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.annotation.IsMember;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
 import org.kkumulkkum.server.dto.promise.response.PromiseDto;
@@ -19,6 +20,7 @@ public class PromiseController {
 
     private final PromiseService promiseService;
 
+    @IsMember(meetingIdParamIndex = 1)
     @PostMapping("/meetings/{meetingId}/promises")
     public ResponseEntity<Void> createPromise(
             @UserId Long userId,
@@ -38,21 +40,21 @@ public class PromiseController {
         return ResponseEntity.ok().build();
     }
 
+    @IsMember(meetingIdParamIndex = 1)
     @GetMapping("/meetings/{meetingId}/promises")
     public ResponseEntity<PromisesDto> getPromises(
-            @UserId final Long userId,
             @PathVariable("meetingId") final Long meetingId,
             @RequestParam(required = false) final Boolean done
     ) {
-        return ResponseEntity.ok().body(promiseService.getPromises(userId, meetingId, done));
+        return ResponseEntity.ok().body(promiseService.getPromises(meetingId, done));
     }
 
+    @IsMember(meetingIdParamIndex = 1)
     @GetMapping("/promises/{promiseId}")
     public ResponseEntity<PromiseDto> getPromise(
-            @UserId final Long userId,
             @PathVariable("promiseId") final Long promiseId
     ) {
-        return ResponseEntity.ok().body(promiseService.getPromise(userId, promiseId));
+        return ResponseEntity.ok().body(promiseService.getPromise(promiseId));
     }
 
 }

--- a/src/main/java/org/kkumulkkum/server/exception/MemberException.java
+++ b/src/main/java/org/kkumulkkum/server/exception/MemberException.java
@@ -1,0 +1,11 @@
+package org.kkumulkkum.server.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.exception.code.MemberErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberException extends RuntimeException {
+    private final MemberErrorCode errorCode;
+}

--- a/src/main/java/org/kkumulkkum/server/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements DefaultErrorCode {
+    // 403 Forbidden
+    NOT_JOINED_MEMBER(HttpStatus.FORBIDDEN, 40310, "모임에 참여하지 않은 회원입니다."),
+    ;
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -20,4 +20,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "JOIN UserInfo ui ON m.user.id = ui.user.id " +
             "WHERE m.meeting.id = :meetingId")
     List<MemberUserInfoDto> findAllByMeetingId(Long meetingId);
+
+    @Query("SELECT CASE WHEN EXISTS (" +
+            "SELECT m FROM Member m " +
+            "JOIN m.meeting mt " +
+            "JOIN m.user u " +
+            "JOIN Promise p ON p.meeting.id = mt.id " +
+            "WHERE p.id = :promiseId AND u.id = :userId" +
+            ") THEN TRUE ELSE FALSE END " +
+            "FROM Member m")
+    boolean existsByPromiseIdAndUserId(Long promiseId, Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -9,8 +9,9 @@ import java.util.List;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END " +
-            "FROM Member m WHERE m.user.id = :userId AND m.meeting.id = :meetingId")
+    @Query("SELECT CASE WHEN EXISTS " +
+            "(SELECT m FROM Member m WHERE m.user.id = :userId AND m.meeting.id = :meetingId) " +
+            "THEN TRUE ELSE FALSE END FROM Member m")
     boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
 
     @Query("SELECT new org.kkumulkkum.server.dto.member.MemberUserInfoDto" +

--- a/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
@@ -33,4 +33,13 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             "WHERE p.promise.id = :promiseId AND p.arrivalAt > pr.time")
     List<ParticipantUserInfoDto> findAllLateComersByPromiseId(Long promiseId);
 
+    @Query("SELECT CASE WHEN EXISTS (" +
+            "SELECT p FROM Participant p " +
+            "JOIN p.member m " +
+            "JOIN m.user u " +
+            "JOIN p.promise pr " +
+            "WHERE pr.id = :promiseId AND u.id = :userId" +
+            ") THEN TRUE ELSE FALSE END " +
+            "FROM Participant p")
+    boolean existsByPromiseIdAndUserId(Long promiseId, Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
@@ -22,4 +22,8 @@ public class MemberRetreiver {
     public List<MemberUserInfoDto> findAllByMeetingId(Long meetingId) {
         return memberRepository.findAllByMeetingId(meetingId);
     }
+
+    public boolean existsByPromiseIdAndUserId(Long promiseId, Long userId) {
+        return memberRepository.existsByPromiseIdAndUserId(promiseId, userId);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRetriever.java
@@ -30,4 +30,7 @@ public class ParticipantRetriever {
         return participantRepository.findAllLateComersByPromiseId(promiseId);
     }
 
+    public boolean existsByPromiseIdAndUserId(Long promiseId, Long userId) {
+        return participantRepository.existsByPromiseIdAndUserId(promiseId, userId);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -65,8 +65,7 @@ public class ParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public ParticipantsDto getParticipants(final Long userId, final Long promiseId) {
-        // TODO: Member 검증
+    public ParticipantsDto getParticipants(final Long promiseId) {
         List<ParticipantStatusUserInfoDto> participants = participantRetriever.findAllByPromiseId(promiseId);
         return ParticipantsDto.from(
                 participants.stream()
@@ -83,8 +82,7 @@ public class ParticipantService {
     }
 
     @Transactional(readOnly = true)
-    public LateComersDto getLateComers(final Long userId, final Long promiseId) {
-        // TODO: MEMBER 검증
+    public LateComersDto getLateComers(final Long promiseId) {
         Promise promise = promiseRetriever.findById(promiseId);
         List<ParticipantUserInfoDto> lateComers = participantRetriever.findAllLateComersByPromiseId(promiseId);
         return LateComersDto.of(

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -28,8 +28,6 @@ public class PromiseService {
 
     @Transactional
     public Long createPromise(Long userId, Long meetingId, PromiseCreateDto createPromiseDto) {
-        // TODO: Member 검증
-
         Promise promise = Promise.builder()
                 .meeting(entityManager.getReference(Meeting.class, meetingId))
                 .name(createPromiseDto.name())
@@ -65,26 +63,18 @@ public class PromiseService {
 
     @Transactional(readOnly = true)
     public PromisesDto getPromises(
-            final Long userId,
             final Long meetingId,
             final Boolean done
     ) {
-        //TODO: Member 검증
-//        memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId);
         List<Promise> promises = promiseRetriever.findAllByMeetingId(meetingId);
-
         return PromisesDto.of(promises, done);
     }
 
     @Transactional(readOnly = true)
     public PromiseDto getPromise(
-            final Long userId,
-            final Long promiseId) {
-
-        //TODO: Member 검증
-//        memberRetreiver.existsByMeetingIdAndUserId(meetingId, userId);
+            final Long promiseId
+    ) {
         Promise promise = promiseRetriever.findById(promiseId);
-
         return PromiseDto.from(promise);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #35 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- IsMember 커스텀 어노테이션을 만들었습니다.
- IsMember에 promiseId의 parameter index를 넣거나 IsMember에 meetingId의 parameter index를 넣는 방법으로 모임에 속한 Member가 맞는지 검증합니다. 입력하지 않은 정보에 대해서는 검증하지 않고 둘 중 하나만 있어도 사용 가능합니다.
- 사용 예시
https://github.com/OMZigak/KKUM_SERVER/blob/308b56cc58403e0b4b2e582cef64c50825590183/src/main/java/org/kkumulkkum/server/controller/PromiseController.java#L23-L29
https://github.com/OMZigak/KKUM_SERVER/blob/308b56cc58403e0b4b2e582cef64c50825590183/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java#L56-L60
- IsParticipant도 필요한줄알고 만들었는데 필요가 없네요... 혹시 나중에 사용처가 생길 수 있으니 일단 두겠습니다. 후에도 사용되지 않는다면 삭제합시다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
IsMember에서 meetingId나 promiseId 둘 다 검증에 사용하기 위해 default 값을 입력하고 if문을 두 번 사용하였는데 이렇게할지 아니면 어노테이션을 분리해서할지 고민이 됩니다.